### PR TITLE
Allow to provide saga extension options down to sagas

### DIFF
--- a/packages/redux-dynamic-modules-saga/README.md
+++ b/packages/redux-dynamic-modules-saga/README.md
@@ -23,7 +23,7 @@ export function getUsersModule(): ISagaModule<IUserState> {
         reducerMap: {
             users: usersReducer,
         },
-        sagas: [userSagas],
+        sagas: [userSagas,{saga:mySagaWithArgument, argument: 'some-value'}],
         // Actions to fire when this module is added/removed
         // initialActions: [],
         // finalActions: [],
@@ -43,6 +43,28 @@ const store: IModuleStore<IState> = configureStore(
 
     /* extensions to include */
     [getSagaExtension(/* saga context object */)],
+
+    getUsersModule()
+    /* ...any additional modules */
+);
+```
+
+
+-   Create a `ModuleStore` and pass options to sagas
+
+```typescript
+import { configureStore, IModuleStore } from "redux-dynamic-modules";
+import { getUsersModule } from "./usersModule";
+import { services } from "./getServices";
+
+const store: IModuleStore<IState> = configureStore(
+    /* initial state */
+    {},
+
+    /* extensions to include */
+    [getSagaExtension(null /* saga context object */,
+                      null /* onError handler */,
+                      services /* value to pass to all sagas */)],
 
     getUsersModule()
     /* ...any additional modules */

--- a/packages/redux-dynamic-modules-saga/src/SagaExtension.ts
+++ b/packages/redux-dynamic-modules-saga/src/SagaExtension.ts
@@ -15,7 +15,8 @@ import { sagaEquals } from "./SagaComparer";
  */
 export function getSagaExtension<C>(
     sagaContext?: C,
-    onError?: (error: Error) => void
+    onError?: (error: Error) => void,
+    options?: any
 ): IExtension {
     let sagaMonitor = undefined;
 
@@ -33,7 +34,7 @@ export function getSagaExtension<C>(
 
     let _sagaManager: IItemManager<
         ISagaRegistration<any>
-    > = getRefCountedManager(getSagaManager(sagaMiddleware), sagaEquals);
+    > = getRefCountedManager(getSagaManager(sagaMiddleware,options), sagaEquals);
 
     return {
         middleware: [sagaMiddleware],

--- a/packages/redux-dynamic-modules-saga/src/SagaManager.ts
+++ b/packages/redux-dynamic-modules-saga/src/SagaManager.ts
@@ -7,7 +7,8 @@ import { IItemManager, getMap } from "redux-dynamic-modules";
  * Creates saga items which can be used to start and stop sagas dynamically
  */
 export function getSagaManager(
-    sagaMiddleware: SagaMiddleware<any>
+    sagaMiddleware: SagaMiddleware<any>,
+    options?:any
 ): IItemManager<ISagaRegistration<any>> {
     const tasks = getMap<ISagaRegistration<any>, Task>(sagaEquals);
 
@@ -19,7 +20,7 @@ export function getSagaManager(
             }
             sagas.forEach(saga => {
                 if (saga && !tasks.get(saga)) {
-                    tasks.add(saga, runSaga(sagaMiddleware, saga));
+                    tasks.add(saga, runSaga(sagaMiddleware, saga, options));
                 }
             });
         },
@@ -43,13 +44,14 @@ export function getSagaManager(
 
 function runSaga(
     sagaMiddleware: SagaMiddleware<any>,
-    sagaRegistration: ISagaRegistration<any>
+    sagaRegistration: ISagaRegistration<any>,
+    options: any
 ): Task {
     if (typeof sagaRegistration === "function") {
         const saga = sagaRegistration as () => Iterator<any>;
-        return sagaMiddleware.run(saga);
+        return sagaMiddleware.run(saga, options);
     }
     const saga = (sagaRegistration as ISagaWithArguments<any>).saga;
     const argument = (sagaRegistration as ISagaWithArguments<any>).argument;
-    return sagaMiddleware.run(saga, argument);
+    return sagaMiddleware.run(saga, argument, options);
 }

--- a/packages/redux-dynamic-modules-saga/src/__tests__/SagaExtension.test.ts
+++ b/packages/redux-dynamic-modules-saga/src/__tests__/SagaExtension.test.ts
@@ -1,26 +1,89 @@
-import { createStore } from "redux-dynamic-modules";
-import { getSagaExtension } from "../SagaExtension";
-import { ISagaModule } from "../Contracts";
-import { SagaIterator } from "redux-saga";
-describe("Saga extension tests", () => {
-    it("Saga extension registers module and starts saga", () => {
+import { createStore } from 'redux-dynamic-modules';
+import { getSagaExtension } from '../SagaExtension';
+import { ISagaModule } from '../Contracts';
+import { SagaIterator } from 'redux-saga';
+describe('Saga extension tests', () => {
+    it('Saga extension registers module and starts saga', () => {
         const testContext = {};
         called = false;
         createStore({}, [], [getSagaExtension(testContext)], getTestModule());
-        expect(called);
+        expect(called).toEqual(true);
+        expect(testContext['moduleManager']).toBeTruthy();
+    });
 
-        expect(testContext["moduleManager"]).toBeTruthy();
+    it('Saga extension registers module and starts saga with context provided', () => {
+        const testContext = {};
+        called = false;
+        const options = true;
+        createStore(
+            {},
+            [],
+            [getSagaExtension(testContext, null, options)],
+            getTestModuleWithOptions()
+        );
+        expect(called).toEqual(true);
+        expect(testContext['moduleManager']).toBeTruthy();
+    });
+
+    it('Saga extension registers module and starts saga with context provided and saga argument', () => {
+        const testContext = {};
+        called = false;
+        calledB = false;
+
+        const options = null;
+        createStore(
+            {},
+            [],
+            [getSagaExtension(testContext, null, options)],
+            getTestModuleWithArgumentAndOptions()
+        );
+        expect(called).toEqual(true);
+        expect(calledB).toEqual(null);
+        // expect(calledB).toEqual(null);
+        expect(testContext['moduleManager']).toBeTruthy();
     });
 });
 
+let called = false;
+let calledB = false;
+function* testSaga(): SagaIterator {
+    called = true;
+}
+
+function* testSagaContext(value?: any): SagaIterator {
+    called = value;
+}
+
+function* testSagaOptionsWithArgument(
+    argument?: any,
+    value?: any
+): SagaIterator {
+    called = argument;
+    calledB = value;
+}
+
 function getTestModule(): ISagaModule<{ a: string }> {
     return {
-        id: "test-module",
+        id: 'test-module',
         sagas: [testSaga],
     };
 }
 
-let called = false;
-function* testSaga(): SagaIterator {
-    called = true;
+function getTestModuleWithOptions(): ISagaModule<{ a: string }> {
+    return {
+        id: 'test-module-options',
+        sagas: [testSagaContext],
+    };
+}
+
+function getTestModuleWithArgumentAndOptions(): ISagaModule<{ a: string }> {
+    return {
+        id: 'test-module-options-argument',
+        sagas: [
+            {
+                saga: testSagaOptionsWithArgument,
+                argument: true,
+            },
+        ],
+    };
 }


### PR DESCRIPTION
This PR allows passing global initialized objects/values to module sagas 

```typescript
import { configureStore, IModuleStore } from "redux-dynamic-modules";
import { getUsersModule } from "./usersModule";
import { services } from "./getServices";
const store: IModuleStore<IState> = configureStore(
    /* initial state */
    {},
    /* extensions to include */
    [getSagaExtension(null /* saga context object */,
                      null /* onError handler */,
                      services /* value to pass to all sagas */)],
    getUsersModule()
    /* ...any additional modules */
);
```

After store is created module saga can retrive global initilized objects via

1. Accessing the first argument of root saga if saga has no argument defined in module
```typescript
function* testSagaContext(services?: any): SagaIterator {
   //use  services here
}
```
2. Accessing the second argument of root saga if saga has argument defined in module
```typescript
function* testSagaOptionsWithArgument(
    argument?: any,
    services?: any
): SagaIterator {
   //use  services here
}```
