### PR TITLE
Fix markdown for headline in docs

### DIFF
--- a/docs/reference/Typescript.md
+++ b/docs/reference/Typescript.md
@@ -1,4 +1,4 @@
-#Typescript
+# Typescript
 `redux-dynamic-modules` is written natively in Typescript and contains types to help you typecheck your module definitions. In this document, we outline some common strategies we use when typing/defining modules.
 
 ## Defining a module's state


### PR DESCRIPTION
Hey,

thanks for this awesome library. While reading the docs I encountered a small bug in the headline of the Typescript markdown page.
I added a space to the markdown of the headline so that it's shown properly.

Cheers

René :octocat: