### PR TITLE
Fix DynamicModuleLoader and remove support for React-Redux 5

### DIFF
--- a/packages/redux-dynamic-modules-react/package.json
+++ b/packages/redux-dynamic-modules-react/package.json
@@ -44,7 +44,7 @@
     },
     "peerDependencies": {
         "react": ">= 15.0.0",
-        "react-redux": ">= 5.0.0",
+        "react-redux": ">= 6.0.0",
         "redux": ">= 3.0.0"
     },
     "dependencies": {

--- a/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
+++ b/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
@@ -101,6 +101,7 @@ class DynamicModuleLoaderImpl extends React.Component<
     private _providerInitializationNeeded: boolean = false;
     private _store: IModuleStore<any>;
     private _getLatestState: boolean;
+    private _memoizedRRContext: any;
 
     constructor(props: IDynamicModuleLoaderImplProps) {
         super(props);
@@ -142,10 +143,23 @@ class DynamicModuleLoaderImpl extends React.Component<
         const { store } = this.props;
         // store.getState is important here as we don't want to use storeState from the provided context
         return (
-            <ReactReduxContext.Provider
-                value={{ store, storeState: store.getState() }}>
-                {this._renderChildren()}
-            </ReactReduxContext.Provider>
+            <ReactReduxContext.Consumer>
+                {rrContext => {
+                    if (rrContext !== this._memoizedRRContext) {
+                        this._memoizedRRContext = {
+                            ...rrContext,
+                            storeState: store.getState(),
+                        };
+                    }
+
+                    return (
+                        <ReactReduxContext.Provider
+                            value={this._memoizedRRContext}>
+                            {this._renderChildren()}
+                        </ReactReduxContext.Provider>
+                    );
+                }}
+            </ReactReduxContext.Consumer>
         );
     };
 

--- a/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
+++ b/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
@@ -52,10 +52,14 @@ class DynamicModuleLoaderImpl extends React.Component<
     IDynamicModuleLoaderImplProps,
     IDynamicModuleLoaderImplState
 > {
+    /** The modules that were added from this loader */
     private _addedModules?: IDynamicallyAddedModule;
+    /** Flag that indicates we need to create a store/provider because a parent store was not provided */
     private _providerInitializationNeeded: boolean = false;
+    /** The module store, derived from context */
     private _store: IModuleStore<any>;
-    private _memoizedRRContext: any;
+    /** The react redux context, saved */
+    private _memoizedReactReduxContext: any;
 
     constructor(props: IDynamicModuleLoaderImplProps) {
         super(props);
@@ -106,15 +110,17 @@ class DynamicModuleLoaderImpl extends React.Component<
         }
 
         // Memoize the context if it has changed upstream
-        if (this.props.reactReduxContext !== this._memoizedRRContext) {
-            this._memoizedRRContext = {
+        // If the context has not changed, we want to use the same object reference so that
+        // downstream consumers do not update needlessly
+        if (this.props.reactReduxContext !== this._memoizedReactReduxContext) {
+            this._memoizedReactReduxContext = {
                 ...this.props.reactReduxContext,
                 storeState: this.props.reactReduxContext.store.getState(),
             };
         }
 
         return (
-            <ReactReduxContext.Provider value={this._memoizedRRContext}>
+            <ReactReduxContext.Provider value={this._memoizedReactReduxContext}>
                 {this.props.children &&
                 typeof this.props.children === "function"
                     ? this.props.children()

--- a/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
+++ b/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
@@ -12,9 +12,15 @@ export interface IDynamicModuleLoaderProps {
     /** Modules that need to be dynamically registerd */
     modules: IModuleTuple;
 
+    /**
+     * Set this flag to indicate that this component is being rendered in 'Strict Mode'
+     * React 'StrictMode' does not allow constructor side-effects, so we defer adding modules to componentDidMount
+     * when this flag is set.
+     * This has the effect of adding a second render.
+     */
     strictMode?: boolean;
 
-    /** Optional callback which returns a store instance. This would be called if no store could be loaded from the context. */
+    /** Optional callback which returns a store instance. This would be called if no store could be loaded from th  e context. */
     createStore?: () => IModuleStore<any>;
 }
 
@@ -41,10 +47,15 @@ export class DynamicModuleLoader extends React.Component<
 }
 
 interface IDynamicModuleLoaderImplProps extends IDynamicModuleLoaderProps {
+    /** The react-redux context passed from the <Provider> component */
     reactReduxContext?: { store: IModuleStore<any> };
 }
 
 interface IDynamicModuleLoaderImplState {
+    /** Is the DML component ready to render.
+     * If strictMode is set to false, this will be set to true initially
+     * If strict mode is set to true, this will be set after the first render completes
+     */
     readyToRender: boolean;
 }
 

--- a/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
+++ b/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
@@ -40,16 +40,15 @@ export class DynamicModuleLoader extends React.Component<
     }
 }
 
-export interface IDynamicModuleLoaderImplProps
-    extends IDynamicModuleLoaderProps {
+interface IDynamicModuleLoaderImplProps extends IDynamicModuleLoaderProps {
     reactReduxContext?: { store: IModuleStore<any> };
 }
 
-export interface IDynamicModuleLoaderImplState {
+interface IDynamicModuleLoaderImplState {
     readyToRender: boolean;
 }
 
-export class DynamicModuleLoaderImpl extends React.Component<
+class DynamicModuleLoaderImpl extends React.Component<
     IDynamicModuleLoaderImplProps,
     IDynamicModuleLoaderImplState
 > {
@@ -128,6 +127,7 @@ export class DynamicModuleLoaderImpl extends React.Component<
         const { createStore, modules } = this.props;
 
         if (!this._store) {
+            // If we need to create a store, do that here. We will skip adding the modules and render DML again
             if (createStore) {
                 this._store = createStore();
                 this._providerInitializationNeeded = true;
@@ -137,6 +137,7 @@ export class DynamicModuleLoaderImpl extends React.Component<
                 );
             }
         } else {
+            // Add the modules here
             this._addedModules = this._store.addModules(modules);
         }
     }


### PR DESCRIPTION
This PR fixes:
* #76: We were not applying ALL of the context values that were provided from `ReactReduxContext`, so do that here.
* When using the `createStore` prop, we were not providing a modified context to the first connected component. Now, if we call `createStore` and render a `Provider`, we will render another instance of `DynamicModuleLoader`, which will actually add the modules.
* While writing this PR, I also decided to simplify the component by removing support for `react-redux@5`

This should result in a major version bump to V4