### PR TITLE
Seed reducers after adding them

### DIFF
--- a/packages/redux-dynamic-modules-core/src/Managers/ModuleManager.ts
+++ b/packages/redux-dynamic-modules-core/src/Managers/ModuleManager.ts
@@ -74,6 +74,7 @@ export function getModuleManager<State>(
             }
         }
 
+        /* Fire an action so that the newly added reducers can seed their initial state */
         _seedReducers();
     };
 

--- a/packages/redux-dynamic-modules-core/src/Managers/ModuleManager.ts
+++ b/packages/redux-dynamic-modules-core/src/Managers/ModuleManager.ts
@@ -26,6 +26,10 @@ export function getModuleManager<State>(
     let _modules: IModule<any>[] = [];
     const _moduleIds = new Set();
 
+    const _seedReducers = () => {
+        _dispatch({ type: "@@Internal/ModuleManager/SeedReducers" });
+    };
+
     const _dispatchActions = (actions: AnyAction[]) => {
         if (!actions) {
             return;
@@ -68,6 +72,8 @@ export function getModuleManager<State>(
             for (const key in reducerMap) {
                 _reducerManager.add(key, reducerMap[key]);
             }
+
+            _seedReducers();
         }
     };
 
@@ -106,6 +112,7 @@ export function getModuleManager<State>(
                     _moduleIds.add(module.id);
                     _modules.push(module);
                     _addReducers(module.reducerMap);
+
                     const middlewares = module.middlewares;
                     if (middlewares) {
                         _addMiddlewares(middlewares);

--- a/packages/redux-dynamic-modules-core/src/Managers/ModuleManager.ts
+++ b/packages/redux-dynamic-modules-core/src/Managers/ModuleManager.ts
@@ -72,9 +72,9 @@ export function getModuleManager<State>(
             for (const key in reducerMap) {
                 _reducerManager.add(key, reducerMap[key]);
             }
-
-            _seedReducers();
         }
+
+        _seedReducers();
     };
 
     const _removeReducers = (

--- a/packages/redux-dynamic-modules-core/src/__tests__/Managers/ModuleManager.test.ts
+++ b/packages/redux-dynamic-modules-core/src/__tests__/Managers/ModuleManager.test.ts
@@ -35,6 +35,7 @@ it("module manager tests", () => {
 
     // Test initial actions are dispatched for module1
     expect(actionsDispatched).toEqual([
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial1",
         "initial11",
@@ -45,9 +46,11 @@ it("module manager tests", () => {
 
     // Test initial actions are dispatched for module2
     expect(actionsDispatched).toEqual([
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial1",
         "initial11",
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial2",
         "initial21",
@@ -58,9 +61,11 @@ it("module manager tests", () => {
 
     // Test final actions are dispatched for module1
     expect(actionsDispatched).toEqual([
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial1",
         "initial11",
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial2",
         "initial21",
@@ -74,9 +79,11 @@ it("module manager tests", () => {
 
     // Test no additional actions are dispatched
     expect(actionsDispatched).toEqual([
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial1",
         "initial11",
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial2",
         "initial21",
@@ -90,9 +97,11 @@ it("module manager tests", () => {
 
     // Test no additional actions are dispatched
     expect(actionsDispatched).toEqual([
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial1",
         "initial11",
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial2",
         "initial21",
@@ -103,6 +112,32 @@ it("module manager tests", () => {
         "final21",
         "@@Internal/ModuleManager/ModuleRemoved",
     ]);
+});
+
+it("When adding a module, the initial state should be seeded immediately", () => {
+    const middlewareManager = getMiddlewareManager();
+    const moduleManager = getModuleManager(middlewareManager, []);
+
+    let actionsDispatched = [];
+
+    moduleManager.setDispatch(action => {
+        // Push the action type to array so we can track it
+        actionsDispatched.push(action.type);
+        return action.payload || null;
+    });
+
+    const reducer = jest.fn(() => state => state || null);
+
+    const module1 = {
+        id: "module1",
+        reducerMap: { duplicateReducer: reducer, key11: reducer },
+    };
+
+    middlewareManager.add = jest.fn(() => {
+        expect(reducer).toBeCalled();
+    });
+
+    moduleManager.add([module1]);
 });
 
 it("Dispose disposes all modules in reverse order they are added", () => {
@@ -139,9 +174,11 @@ it("Dispose disposes all modules in reverse order they are added", () => {
     moduleManager.dispose();
 
     expect(actionsDispatched).toEqual([
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial1",
         "initial11",
+        "@@Internal/ModuleManager/SeedReducers",
         "@@Internal/ModuleManager/ModuleAdded",
         "initial2",
         "initial21",


### PR DESCRIPTION
Issue: When reducers were added, we did not dispatch an action to seed them with initial state. This meant that the initial state was not available to any of the extensions of the module.

Fix:
Seed the reducers by firing an action after adding them