### PR TITLE
Introducing retained flag in modules so they are retained even when the component is unmounted

### DIFF
--- a/packages/redux-dynamic-modules-core/src/Contracts.ts
+++ b/packages/redux-dynamic-modules-core/src/Contracts.ts
@@ -28,6 +28,11 @@ export interface IModule<State> {
      * These actions are dispatched immediatly before removing the module from the store
      */
     finalActions?: AnyAction[];
+
+    /**
+     * Specifies if the module is retained forever in the store
+     */
+    retained?: boolean;
 }
 
 export interface IExtension {

--- a/packages/redux-dynamic-modules-core/src/Managers/RefCountedManager.ts
+++ b/packages/redux-dynamic-modules-core/src/Managers/RefCountedManager.ts
@@ -9,7 +9,7 @@ export function getRefCountedManager<IType extends IItemManager<T>, T>(
 	equals: (a: T, b: T) => boolean,
 	retained?: (a: T) => boolean // Decides if the item is retained even when the ref count reaches 0 
 ): IType {
-	let refCounter = getObjectRefCounter<T>(equals, retained || (() => false));
+	let refCounter = getObjectRefCounter<T>(equals, retained);
     const items = manager.getItems();
     // Set initial ref counting
     items.forEach(item => refCounter.add(item));

--- a/packages/redux-dynamic-modules-core/src/Managers/RefCountedManager.ts
+++ b/packages/redux-dynamic-modules-core/src/Managers/RefCountedManager.ts
@@ -6,9 +6,10 @@ import { IItemManager } from "../Contracts";
  */
 export function getRefCountedManager<IType extends IItemManager<T>, T>(
     manager: IType,
-    equals: (a: T, b: T) => boolean
+	equals: (a: T, b: T) => boolean,
+	retained?: (a: T) => boolean // Decides if the item is retained even when the ref count reaches 0 
 ): IType {
-    let refCounter = getObjectRefCounter<T>(equals);
+	let refCounter = getObjectRefCounter<T>(equals, retained || (() => false));
     const items = manager.getItems();
     // Set initial ref counting
     items.forEach(item => refCounter.add(item));

--- a/packages/redux-dynamic-modules-core/src/Utils/RefCounter.ts
+++ b/packages/redux-dynamic-modules-core/src/Utils/RefCounter.ts
@@ -16,10 +16,15 @@ export interface IRefCounter<T> {
 
 /** Ref counts given object */
 export function getObjectRefCounter<T>(
-    equals: (a: T, b: T) => boolean
+    equals: (a: T, b: T) => boolean,
+    retained: (a: T) => boolean
 ): IRefCounter<T> {
     if (!equals) {
         equals = (a, b) => a === b;
+    }
+
+    if(!retained) {
+        retained = () => false;
     }
     const objects: T[] = [];
     const counts: number[] = [];
@@ -54,12 +59,22 @@ export function getObjectRefCounter<T>(
             } else {
                 count = counts[index] + 1;
             }
+
+            // If item is retained then keep it for inifinty
+            if (retained(obj)) {
+                count = Infinity;
+            }
+            
             counts[index] = count;
         },
         /**
          * Decreases ref count for given T, if refcount reaches to zero removes the T and returns true
          */
         remove: (obj: T): boolean => {
+            if (retained(obj)) {
+                return false;
+            }
+            
             let index = objects.findIndex(o => o && equals(o, obj));
             if (index === -1) {
                 return false;

--- a/packages/redux-dynamic-modules-core/src/Utils/RefCounter.ts
+++ b/packages/redux-dynamic-modules-core/src/Utils/RefCounter.ts
@@ -17,7 +17,7 @@ export interface IRefCounter<T> {
 /** Ref counts given object */
 export function getObjectRefCounter<T>(
     equals: (a: T, b: T) => boolean,
-    retained: (a: T) => boolean
+    retained?: (a: T) => boolean
 ): IRefCounter<T> {
     if (!equals) {
         equals = (a, b) => a === b;

--- a/packages/redux-dynamic-modules-core/src/__tests__/Utils/RefCounter.test.ts
+++ b/packages/redux-dynamic-modules-core/src/__tests__/Utils/RefCounter.test.ts
@@ -48,6 +48,26 @@ it("tests object ref counter", () => {
     expect(refCounter.getCount(a)).toBe(0);
 });
 
-function foobar() {}
+it("tests object ref counter when objects are retained", () => {
+    const refCounter = getObjectRefCounter<Function>((a, b) => a === b, () => true);
+    expect(refCounter.getCount(foobar)).toBe(0);
+
+    refCounter.add(a);
+    expect(refCounter.getCount(a)).toBe(Infinity);
+
+    refCounter.add(a);
+    expect(refCounter.getCount(a)).toBe(Infinity);
+
+    expect(refCounter.remove(a)).toBe(false);
+    expect(refCounter.getCount(a)).toBe(Infinity);
+
+    expect(refCounter.remove(a)).toBe(false);
+    expect(refCounter.getCount(a)).toBe(Infinity);
+
+    expect(refCounter.remove(a)).toBe(false);
+    expect(refCounter.getCount(a)).toBe(Infinity);
+});
+
+function foobar() { }
 
 function a() {}


### PR DESCRIPTION
@ahrnee I have introduced a retained flag in IModule that is respected by the RefCounter to keep the module for infinity.  This is an alternate implementation to #86