### PR TITLE
removing added modules after children "unmounting"

### DIFF
--- a/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
+++ b/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
@@ -73,7 +73,6 @@ class DynamicModuleLoaderImpl extends React.Component<
     constructor(props: IDynamicModuleLoaderImplProps) {
         super(props);
 
-        this._cleanup = this._cleanup.bind(this);
         if (props.reactReduxContext == null) {
             const message =
                 "Tried to render DynamicModuleLoader, but no ReactReduxContext was provided";
@@ -160,7 +159,7 @@ class DynamicModuleLoaderImpl extends React.Component<
     /**
      * Unregister sagas and reducers
      */
-    private _cleanup(): void {
+    private _cleanup = () => {
         if (this._addedModules) {
             this._addedModules.remove();
             this._addedModules = undefined;


### PR DESCRIPTION
see issue https://github.com/microsoft/redux-dynamic-modules/issues/85
______________
react runs willUnmount from parent and down the tree,

so willUnmount is run firstly on DynamicModuleLoader and only then on connected children

DynamicModuleLoader removes dynamic reducers on willUnmount that leads to store's state change and running selectors  in connected children

these selectors migh failed because there is no more part of store that was added by dynamic module.
_______________________
current version works fine with prev version of react-redux just because prev version throws selector's error only on rendering
see https://github.com/reduxjs/react-redux/blob/v5.1.1/src/components/connectAdvanced.js#L257  

But new version also throws selector error on "unmounting"
https://github.com/reduxjs/react-redux/pull/1209/commits/96fec159e2afb8649321d8cd61841b9cf406ae8f#diff-4a561361865a8e6d0758088bf7cded8dR363
_________

To fix it added one more component as last child of `DynamicModuleLoader` and removes added modules when this component is unmounted (so other children has a chance to unsubscribe from store changes)