### PR TITLE
Update README to reflect new createStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,11 @@ export function getUsersModule(): IModule<IUserState> {
 import { createStore, IModuleStore } from "redux-dynamic-modules";
 import { getUsersModule } from "./usersModule";
 
-const store: IModuleStore<IState> = createStore(
-    /* initial state */
-    {},
-
-    /** enhancers **/
-    [],
-
-    /* extensions to include */
-    [],
-
+const store: IModuleStore<IState> = createStore({
+      initialState: { /** initial state */ },
+      enhancers: { /** enhancers to include */ }, 
+      extensions: [/** extensions to include i.e. getSagaExtension(), getThunkExtension() */],
+},
     getUsersModule()
     /* ...any additional modules */
 );

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ import { getUsersModule } from "./usersModule";
 
 const store: IModuleStore<IState> = createStore({
       initialState: { /** initial state */ },
-      enhancers: { /** enhancers to include */ }, 
+      enhancers: [ /** enhancers to include */ ], 
       extensions: [/** extensions to include i.e. getSagaExtension(), getThunkExtension() */],
 },
     getUsersModule()


### PR DESCRIPTION
README is out of date for `createStore`!

createStore used to take initialState/enchancers/extensions as parameters but now the first parameter contains these objects.