### PR TITLE
Adding more links to Devtools.md

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,3 +13,4 @@
     -   [Extensions](reference/Extensions.md)
     -   [Lifecycle Actions](reference/LifecycleActions.md)
     -   [Usage with Typescript](reference/Typescript.md)
+    -   [Redux Devtools Extension](reference/Devtools.md)

--- a/docs/reference/ModuleStore.md
+++ b/docs/reference/ModuleStore.md
@@ -33,3 +33,4 @@ You can pass additional properties to `createStore` to further customize its usa
 -   `extensions: IExtension[]`: Any extensions you want to run along with the store. See [Extensions](Extensions.md) for more info.
 -   `enhancers: Enhancer[]`: Any Redux enhancers you want to add. These will automatically be composed together.
 -   `advancedCombineReducers`: Provide a custom implementation of `combineReducers`, which can be helpful for working with libraries like ImmutableJS. [See Here](https://github.com/gajus/redux-immutable)
+-   `advancedComposeEnhancers`: Override enhancer composition. Check out [Redux Devtools Extension](Devtools.md) for a sample usage.


### PR DESCRIPTION
The website does not list information about advancedComposeEnhancers as seen here: https://github.com/microsoft/redux-dynamic-modules/blob/master/docs/reference/Devtools.md.

Also, this page should have a hint about it: https://redux-dynamic-modules.js.org/#/reference/ModuleStore