### PR TITLE
Simplify the empty epic to actually do nothing

### DIFF
--- a/packages/redux-dynamic-modules-observable/src/EpicManager.ts
+++ b/packages/redux-dynamic-modules-observable/src/EpicManager.ts
@@ -1,5 +1,5 @@
 import { getObjectRefCounter, IItemManager } from "redux-dynamic-modules-core";
-import { Epic, ofType, EpicMiddleware } from "redux-observable";
+import { Epic, EpicMiddleware } from "redux-observable";
 import { Observable, Subject } from "rxjs";
 import { ignoreElements, switchMap } from "rxjs/operators";
 

--- a/packages/redux-dynamic-modules-observable/src/EpicManager.ts
+++ b/packages/redux-dynamic-modules-observable/src/EpicManager.ts
@@ -1,7 +1,7 @@
 import { getObjectRefCounter, IItemManager } from "redux-dynamic-modules-core";
 import { Epic, ofType, EpicMiddleware } from "redux-observable";
 import { Observable, Subject } from "rxjs";
-import { mapTo, switchMap } from "rxjs/operators";
+import { ignoreElements, switchMap } from "rxjs/operators";
 
 export interface IEpicManager extends IItemManager<Epic> {
     // some extra properties
@@ -121,7 +121,6 @@ function createReplaceableWrapper() {
  */
 function emptyEpic(action$) {
     return action$.pipe(
-        ofType("noop"),
-        mapTo({ type: "noop" })
+        ignoreElements()
     );
 }


### PR DESCRIPTION
The current `emptyEpic` could create an infinite loop if an end user actually dispatched an element of type `noop`. Using `ignoreElements` instead will just sink all actions.