### PR TITLE
Fix incorrect documentation for redux-dynamic-modules-saga

### DIFF
--- a/docs/reference/ReduxSaga.md
+++ b/docs/reference/ReduxSaga.md
@@ -13,17 +13,13 @@ import { getSagaExtension } from "redux-dynamic-modules-saga";
 import { getUsersModule } from "./usersModule";
 
 const store: IModuleStore<IState> = createStore(
-    /* initial state */
-    {},
-
-    /** enhancers **/
-    [],
-
-    /* Extensions to load */
-    [getSagaExtension({} /* saga context */)],
-
-    getUsersModule()
-    /* ...any additional modules */
+  {
+    initialState: {},
+    enhancers: [],
+    extensions: [getSagaExtension({} /* saga context */)],
+  },
+  getUsersModule()
+  /* ...any additional modules */
 );
 ```
 

--- a/packages/redux-dynamic-modules-saga/README.md
+++ b/packages/redux-dynamic-modules-saga/README.md
@@ -39,13 +39,12 @@ import { getSagaExtension } from "redux-dynamic-modules-saga";
 import { getUsersModule } from "./usersModule";
 
 const store: IModuleStore<IState> = createStore(
-    /* initial state */
-    {},
-
-    /* extensions to include */
-    [getSagaExtension(/* saga context object */)],
-
-    getUsersModule()
-    /* ...any additional modules */
+  {
+    initialState: {},
+    enhancers: [],
+    extensions: [getSagaExtension({} /* saga context */)],
+  },
+  getUsersModule()
+  /* ...any additional modules */
 );
 ```

--- a/packages/redux-dynamic-modules-saga/README.md
+++ b/packages/redux-dynamic-modules-saga/README.md
@@ -34,10 +34,11 @@ export function getUsersModule(): ISagaModule<IUserState> {
 -   Create a `ModuleStore`
 
 ```typescript
-import { configureStore, IModuleStore } from "redux-dynamic-modules";
+import { createStore, IModuleStore } from "redux-dynamic-modules";
+import { getSagaExtension } from "redux-dynamic-modules-saga";
 import { getUsersModule } from "./usersModule";
 
-const store: IModuleStore<IState> = configureStore(
+const store: IModuleStore<IState> = createStore(
     /* initial state */
     {},
 


### PR DESCRIPTION
The documentation for this plugin (and as a result, the documentation on NPM) is incorrect. `redux-dynamic-modules` doesn't export `configureStore` and the user needs to import `getSagaExtension`, which was missing before. I've changed also changed the ReduxSaga reference doc in `docs` to match as that also appeared to be slightly out of date