### PR TITLE
Provide access to saga completion promise

### DIFF
--- a/packages/redux-dynamic-modules-saga/src/Contracts.ts
+++ b/packages/redux-dynamic-modules-saga/src/Contracts.ts
@@ -1,4 +1,4 @@
-import { IModule } from "redux-dynamic-modules-core";
+import { IExtension, IItemManager, IModule } from "redux-dynamic-modules-core";
 
 export interface ISagaWithArguments<T> {
     saga: (argument?: T) => Iterator<any>;
@@ -7,6 +7,14 @@ export interface ISagaWithArguments<T> {
 export type ISagaRegistration<T> =
     | (() => Iterator<any>)
     | ISagaWithArguments<T>;
+
+export interface ISagaManager extends IItemManager<ISagaRegistration<any>> {
+  done: () => Promise<any>;
+}
+
+export interface ISagaExtension extends IExtension {
+  done: () => Promise<any>;
+}
 
 export interface ISagaModule<T> extends IModule<T> {
     sagas?: ISagaRegistration<any>[];

--- a/packages/redux-dynamic-modules-saga/src/SagaExtension.ts
+++ b/packages/redux-dynamic-modules-saga/src/SagaExtension.ts
@@ -1,11 +1,9 @@
 import { default as createSagaMiddleware, SagaMiddleware } from "redux-saga";
 import {
-    IExtension,
-    IItemManager,
     getRefCountedManager,
     IModuleManager,
 } from "redux-dynamic-modules-core";
-import { ISagaRegistration, ISagaModule } from "./Contracts";
+import { ISagaExtension, ISagaManager, ISagaModule } from "./Contracts";
 import { getSagaManager } from "./SagaManager";
 import { sagaEquals } from "./SagaComparer";
 
@@ -16,11 +14,14 @@ import { sagaEquals } from "./SagaComparer";
 export function getSagaExtension<C>(
     sagaContext?: C,
     onError?: (error: Error) => void
-): IExtension {
+): ISagaExtension {
     let sagaMonitor = undefined;
 
     //@ts-ignore
-    if (process.env.NODE_ENV === "development" && typeof window !== "undefined") {
+    if (
+        process.env.NODE_ENV === "development" &&
+        typeof window !== "undefined"
+    ) {
         sagaMonitor = window["__SAGA_MONITOR_EXTENSION__"] || undefined;
     }
 
@@ -31,9 +32,10 @@ export function getSagaExtension<C>(
         onError,
     });
 
-    let _sagaManager: IItemManager<
-        ISagaRegistration<any>
-    > = getRefCountedManager(getSagaManager(sagaMiddleware), sagaEquals);
+    let _sagaManager: ISagaManager = getRefCountedManager(
+        getSagaManager(sagaMiddleware),
+        sagaEquals
+    );
 
     return {
         middleware: [sagaMiddleware],
@@ -59,5 +61,7 @@ export function getSagaExtension<C>(
         dispose: () => {
             _sagaManager.dispose();
         },
+
+        done: () => _sagaManager.done(),
     };
 }

--- a/packages/ssr-example/.gitignore
+++ b/packages/ssr-example/.gitignore
@@ -1,0 +1,1 @@
+./lib/ssr-example.js

--- a/packages/ssr-example/README.md
+++ b/packages/ssr-example/README.md
@@ -1,0 +1,11 @@
+# `ssr-example`
+
+An example of SSR rendering after waiting for running sagas to complete.
+
+## Usage Scripts
+
+In the project directory, you can run:
+
+### `npm start`
+
+Runs the app.

--- a/packages/ssr-example/package.json
+++ b/packages/ssr-example/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "ssr-example",
+    "version": "5.2.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+      "build": "tsc",
+      "start": "tsc && node lib/index.js"
+    },
+    "dependencies": {
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0",
+        "react-redux": "7.1.0",
+        "redux": "4.0.1",
+        "redux-dynamic-modules-core": "^5.2.0",
+        "redux-dynamic-modules-react": "^5.2.0",
+        "redux-dynamic-modules-saga": "^5.2.0",
+        "redux-saga": "0.16.2",
+        "typescript": "^3.2.2"
+    }
+}

--- a/packages/ssr-example/src/ssr-example.tsx
+++ b/packages/ssr-example/src/ssr-example.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { AnyAction } from "redux";
+import { connect, Provider } from "react-redux";
+import { take, put } from "redux-saga/effects";
+import { END, delay } from "redux-saga";
+
+import { createStore } from "redux-dynamic-modules-core";
+import { getSagaExtension, ISagaModule } from "redux-dynamic-modules-saga";
+
+interface ValueState {
+    value: number;
+}
+
+interface RootState {
+    values: ValueState;
+}
+
+function reducer(state: ValueState = { value: 1 }, action: AnyAction) {
+    switch (action.type) {
+        case "GET_VALUE_SUCCESS":
+            return {
+                ...state,
+                value: action.value,
+            };
+        default:
+            return state;
+    }
+}
+
+function* saga() {
+    yield take("GET_VALUE_REQUEST");
+    yield delay(1000);
+    yield put({
+        type: "GET_VALUE_SUCCESS",
+        value: 5,
+    });
+}
+
+function getValuesModule(): ISagaModule<RootState> {
+    return {
+        id: "values",
+        reducerMap: {
+            values: reducer,
+        },
+        sagas: [saga],
+    };
+}
+
+const sagaExtension = getSagaExtension();
+
+const store = createStore(
+    {
+        initialState: {
+            values: {
+                value: 1,
+            },
+        },
+        extensions: [sagaExtension],
+    },
+    getValuesModule()
+);
+
+const Component: React.FC<ValueState> = ({ value }) => <div>{value}</div>;
+
+const Container = connect((state: RootState) => state.values)(Component);
+
+async function ssr() {
+    console.log(
+        "Initial state:",
+        ReactDOMServer.renderToString(
+            <Provider store={store}>
+                <Container />
+            </Provider>
+        )
+    );
+
+    store.dispatch({ type: "GET_VALUE_REQUEST" });
+    store.dispatch(END);
+    await sagaExtension.done();
+    console.log(
+        "After waiting for sagas:",
+        ReactDOMServer.renderToString(
+            <Provider store={store}>
+                <Container />
+            </Provider>
+        )
+    );
+}
+
+ssr();

--- a/packages/ssr-example/tsconfig.json
+++ b/packages/ssr-example/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "jsx": "react",
+        "outDir": "lib"
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
For SSR it can be useful to run some sagas and await their completion before rendering the page. Eg:

```typescript
// Run apiSaga
const sagaTask = sagaMiddleware.run(apiSaga);
// Send an action apiSaga is waiting for
store.dispatch({ type: 'GET_DATA_FROM_API' });
// Cancel all sagas still waiting for actions
store.dispatch(END);
// Await completion of sagas not waiting for actions
// This allows apiSaga to finish the api query and 'put' the data to the store
await sagaTask.done;
// Render the page including the api data
renderSSR();
```

This PR adds a function to the `redux-dynamic-modules-saga` `IExtension` to get a promise for the completion of all currently running sagas, allowing the above pattern when using `redux-dynamic-modules`. Eg:

```typescript
const sagaExtension = getSagaExtension({});
const store: IModuleStore<IState> = createStore(
  {
    initialState: {},
    enhancers: [],
    extensions: [sagaExtension],
  },
  getApiModule()
);
store.dispatch({ type: 'GET_DATA_FROM_API' });
store.dispatch(END);
await sagaExtension.done();
renderSSR();
```