### PR TITLE
Add children to the props for @types/react@18

### DIFF
--- a/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
+++ b/packages/redux-dynamic-modules-react/src/DynamicModuleLoader.tsx
@@ -9,6 +9,8 @@ import {
 } from "redux-dynamic-modules-core";
 
 export interface IDynamicModuleLoaderProps {
+    /** Explicitly name children as a prop to work with @types/react@18 */
+    children: React.ReactNode;
     /** Modules that need to be dynamically registerd */
     modules: IModuleTuple;
 


### PR DESCRIPTION
In relation to React props should not do anything special with `children` and DefinitelyTyped have updated the react types to v18

https://github.com/DefinitelyTyped/DefinitelyTyped/issues/59802